### PR TITLE
change msg structure for realtime processing

### DIFF
--- a/yolov8_ros/yolov8_msgs/CMakeLists.txt
+++ b/yolov8_ros/yolov8_msgs/CMakeLists.txt
@@ -26,6 +26,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Detection.msg"
   "msg/DetectionArray.msg"
   "msg/DetectionInfo.msg"
+  "msg/BBoxYolo.msg"
   "msg/FaceBox2D.msg"
   "srv/Person.srv"
   DEPENDENCIES std_msgs geometry_msgs

--- a/yolov8_ros/yolov8_msgs/msg/BBoxYolo.msg
+++ b/yolov8_ros/yolov8_msgs/msg/BBoxYolo.msg
@@ -1,0 +1,5 @@
+# [] = (x, y) | 2D position and orientation of the bounding box center
+int32[] leftup
+
+# [] = (x, y) | total size of the bounding box, in pixels, surrounding the object's center
+int32[] rightbottom

--- a/yolov8_ros/yolov8_msgs/msg/Detection.msg
+++ b/yolov8_ros/yolov8_msgs/msg/Detection.msg
@@ -13,11 +13,11 @@ bool istrack
 # 2D bounding box surrounding the object in pixels
 yolov8_msgs/BoundingBox2D bbox
 
+# yolo format | 2D bounding box surrounding the object in pixels
+yolov8_msgs/BBoxYolo bboxyolo
+
 # 2D bounding box for face recognition
 yolov8_msgs/FaceBox2D facebox
-
-# 3D bounding box surrounding the object in meters
-# yolov8_msgs/BoundingBox3D bbox3d
 
 # segmentation mask of the detected object
 # it is only the boundary of the segmented object
@@ -25,6 +25,3 @@ yolov8_msgs/Mask mask
 
 # keypoints for human pose estimation
 yolov8_msgs/KeyPoint2DArray keypoints
-
-# keypoints for human pose estimation
-# yolov8_msgs/KeyPoint3DArray keypoints3d

--- a/yolov8_ros/yolov8_msgs/msg/FaceBox2D.msg
+++ b/yolov8_ros/yolov8_msgs/msg/FaceBox2D.msg
@@ -6,5 +6,5 @@ float64 score
 
 bool isdetect
 
-# 2D bounding box surrounding the object in pixels
-yolov8_msgs/BoundingBox2D bbox
+# YOLO format's 2D bounding box surrounding the object in pixels
+yolov8_msgs/BBoxYolo bbox


### PR DESCRIPTION
## msg 구조를 변경하여, 이중 계산하는 부분을 없앴다.
msg 값이 B타입일 때, (A -> B 이후 B->A) 계산을 했지만, 새로운 msg 타입 A를 만들어 계산하는 부분을 없앴다.
- A타입: leftup.x, leftup.y, rightbottom.x, rightbottom.y
- B타입: center.x, center.y, size.x, size.y